### PR TITLE
Deleted population tables

### DIFF
--- a/freespaceService.js
+++ b/freespaceService.js
@@ -123,7 +123,7 @@ function readCurrentStatusid(req, res, next) {
 //  Only takes the reports that have been submitted within the last two hours along with the
 //  basis zero-value reports (used for averaging).
 function readLocationStatuses(req, res, next) {
-    db.many("SELECT LocationID as key, LocationID, name, AVG(status) as statusAverage FROM \
+    db.many("SELECT LocationID as key, LocationID, name, maxCapacity, AVG(status) as statusAverage FROM \
                 (\
                     SELECT *\
                     FROM StatusReport \
@@ -131,7 +131,7 @@ function readLocationStatuses(req, res, next) {
                     OR date(reportedTime) = '2020-1-20' \
                 ) AS FilterQuery, Location \
                 WHERE LocationID = Location.ID \
-                GROUP BY name, LocationID \
+                GROUP BY name, LocationID, maxCapacity \
                 ORDER BY LocationID \
             ;")
         .then(data => {

--- a/freespaceService.js
+++ b/freespaceService.js
@@ -123,7 +123,8 @@ function readCurrentStatusid(req, res, next) {
 //  Only takes the reports that have been submitted within the last two hours along with the
 //  basis zero-value reports (used for averaging).
 function readLocationStatuses(req, res, next) {
-    db.many("SELECT LocationID as key, LocationID, name, maxCapacity, AVG(status) as statusAverage FROM \
+    db.many("SELECT LocationID as key, LocationID, name, maxCapacity, \
+             AVG(status) as statusAverage, COUNT(*) as numReports FROM \
                 (\
                     SELECT *\
                     FROM StatusReport \

--- a/sql/freespace-queries.sql
+++ b/sql/freespace-queries.sql
@@ -37,12 +37,12 @@ SELECT LocationID as key, LocationID, name, AVG(status) as statusAverage
 -- Similar to the above query, but only takes the reports that have been submitted 
 --  within the last two hours OR the reports that have been submitted on January 20, 2020
 -- (we use this date for the initial zero-value records in the StatusReport table).
-SELECT LocationID as key, LocationID, name, maxCapacity, AVG(status) as statusAverage 
+SELECT LocationID as key, LocationID, name, maxCapacity, AVG(status) as statusAverage, COUNT(*) as numReports
   FROM
   (
     SELECT *
     FROM StatusReport
-    WHERE reportedTime >= NOW() - INTERVAL '2 hours' 
+    WHERE reportedTime >= NOW() - INTERVAL '2 hours'
     OR date(reportedTime) = '2020-1-20'
   ) AS FilterQuery, Location
   WHERE LocationID = Location.ID

--- a/sql/freespace-queries.sql
+++ b/sql/freespace-queries.sql
@@ -7,19 +7,45 @@ SELECT *
   FROM StatusReport
   ;
 
--- Get the list of number of card swipes report
-SELECT * 
-  FROM CurrentPopulation
-  ;
-
 -- Get the list of Calvin locations registered in the system
 SELECT *
-  FROM Location
- ;
+  FROM Locations
+  ;
 
+-- Get the list of locations with capacity greater than 100
+SELECT LocationName
+  FROM Locations
+  WHERE MaxCapacity > 100
+  ;
 
--- Get the list of locations with capacity greater than 300
-SELECT name
-  FROM Location
-  WHERE MaxCapacity > 300
-   ;
+-- Get the reports that have been submitted within the past two hours
+SELECT *
+  FROM StatusReport
+  WHERE reportedTime >= NOW() - INTERVAL '2 hours'
+  AND 
+  ;
+
+-- Join the StatusReport and Location tables and return a table specifying the average status for each location.
+--  Ordered by the locations' ID numbers.
+SELECT LocationID as key, LocationID, name, AVG(status) as statusAverage 
+  FROM StatusReport, Location
+  WHERE LocationID = Location.ID
+  GROUP BY name, LocationID
+  ORDER BY LocationID
+;
+
+-- Similar to the above query, but only takes the reports that have been submitted 
+--  within the last two hours OR the reports that have been submitted on January 20, 2020
+-- (we use this date for the initial zero-value records in the StatusReport table).
+SELECT LocationID as key, LocationID, name, AVG(status) as statusAverage 
+  FROM
+  (
+    SELECT *
+    FROM StatusReport
+    WHERE reportedTime >= NOW() - INTERVAL '2 hours' 
+    OR date(reportedTime) = '2020-1-20'
+  ) AS FilterQuery, Location
+  WHERE LocationID = Location.ID
+  GROUP BY name, LocationID
+  ORDER BY LocationID
+;

--- a/sql/freespace-queries.sql
+++ b/sql/freespace-queries.sql
@@ -37,7 +37,7 @@ SELECT LocationID as key, LocationID, name, AVG(status) as statusAverage
 -- Similar to the above query, but only takes the reports that have been submitted 
 --  within the last two hours OR the reports that have been submitted on January 20, 2020
 -- (we use this date for the initial zero-value records in the StatusReport table).
-SELECT LocationID as key, LocationID, name, AVG(status) as statusAverage 
+SELECT LocationID as key, LocationID, name, maxCapacity, AVG(status) as statusAverage 
   FROM
   (
     SELECT *
@@ -46,6 +46,6 @@ SELECT LocationID as key, LocationID, name, AVG(status) as statusAverage
     OR date(reportedTime) = '2020-1-20'
   ) AS FilterQuery, Location
   WHERE LocationID = Location.ID
-  GROUP BY name, LocationID
+  GROUP BY name, LocationID, maxCapacity
   ORDER BY LocationID
 ;

--- a/sql/freespace.sql
+++ b/sql/freespace.sql
@@ -6,15 +6,13 @@
 
 -- Drop previous versions of the tables if they they exist, in reverse order of foreign keys.
 DROP TABLE IF EXISTS StatusReport;
-DROP TABLE IF EXISTS CurrentPopulation;
 DROP TABLE IF EXISTS Location;
 
 -- List of locations shown in the app
 CREATE TABLE Location (
     ID SERIAL PRIMARY KEY,
     name varchar(40),
-    maxCapacity int,
-    imageLocation varchar(50)
+    maxCapacity int
     );
 
 -- List of current status reports made by users
@@ -25,45 +23,26 @@ CREATE TABLE StatusReport (
     reportedTime TIMESTAMP
     );
 
--- List of actual card swipe number reports from dining halls
-CREATE TABLE CurrentPopulation (
-    ID SERIAL PRIMARY KEY,
-    locationID int references Location(ID),
-    estimatedPopulation int,
-    reportedTime TIME,
-    reportedDay varchar(10),
-    cardSwipeNumber int
-    );
-
-
 -- Allow users to select data from the tables.
 GRANT SELECT ON Location TO PUBLIC;
 GRANT SELECT ON StatusReport TO PUBLIC;
-GRANT SELECT ON CurrentPopulation TO PUBLIC;
 
--- Sample data to populate the tables
-INSERT INTO Location (name, maxCapacity, imageLocation) VALUES
-    ('Commons Dining Hall', 500, '../assets/locations/commons.jpg'),
-    ('Knollcrest Dining Hall', 400, '../assets/locations/knollcrest.jpg'),
-    ('Uppercrust', 100, '../assets/locations/uppercrust.jpg'),
-    ('Johnny''s', 100, '../assets/locations/johnnys2.jpg'),
-    ('Peet''s', 50, '../assets/locations/peets.jpg')
+-- Data to set up locations
+INSERT INTO Location (name, maxCapacity) VALUES
+    ('Commons Dining Hall', 141),
+    ('Knollcrest Dining Hall', 120),
+    ('Uppercrust', 47),
+    ('Johnny''s', 25),
+    ('Peet''s', 15)
     ;
 
-
+-- Data to set up reports (used in client to render locations)
+--  We use January 20, 2020 as the date in order to query the base
+--  zero-value records from the database (used for averaging purposes).
 INSERT INTO StatusReport( status, locationID, reportedTime) VALUES
-    (3,  1, '2020-10-16 13:30:00'),
-    (2, 2, '2020-10-16 14:20:00'),
-    (4, 3, '2020-10-16 15:10:00'),
-    (5,  1, '2020-10-16 13:40:00')
-    ;
-
-
-INSERT INTO CurrentPopulation(locationID, estimatedPopulation, reportedTime, reportedDay, cardSwipeNumber) VALUES
-    (1, 200, '13:30:00', 'Monday', 100),
-    (1, 150, '13:45:00', 'Monday', 50),
-    (2, 150,  '13:30:00', 'Monday', 60),
-    (2, 160,  '13:45:00', 'Monday', 100),
-    (3, 140,  '13:30:00', 'Monday', 80),
-    (3, 200,'13:45:00', 'Monday', 120)
+    (0, 1, '2020-1-20 20:20:20'),
+    (0, 2, '2020-1-20 20:20:20'),
+    (0, 3, '2020-1-20 20:20:20'),
+    (0, 4, '2020-1-20 20:20:20'),
+    (0, 5, '2020-1-20 20:20:20')
     ;


### PR DESCRIPTION
Updates:
- Deleted population table
- Deleted population table queries
- Updated StatusReport and Location table join query to only grab records submitted within the past two hours, along with the records with the date '2020-1-2020'. This is the date we use to form the basis of our StatusReport table, and their status values are 0 in order to have the cards render in the Home Screen.
- Added documentation